### PR TITLE
add 'thread' return type from middleware call

### DIFF
--- a/src/Spore/Core.lua
+++ b/src/Spore/Core.lua
@@ -20,7 +20,12 @@ local function _enable_if (self, cond, mw, args)
     local _m = require(mw)
     assert(type(_m.call) == 'function', mw .. " without a function call")
     local f = function (req)
-        return _m.call(args, req)
+        local res = _m.call(args, req)
+        if type(res) == 'thread' then
+            coroutine.yield()
+            res = select(2, coroutine.resume(res))
+        end
+        return res
     end
     local t = self.middlewares; t[#t+1] = { cond = cond, code = f }
 end


### PR DESCRIPTION
which could be used to implement async http request like [this](https://github.com/koreader/koreader/blob/master/plugins/kosync.koplugin/KOSyncClient.lua#L29-L53).